### PR TITLE
Update ota_fetch.c

### DIFF
--- a/src/services/ota/impl/ota_fetch.c
+++ b/src/services/ota/impl/ota_fetch.c
@@ -60,7 +60,7 @@ int32_t ofc_Fetch(void *handle, char *buf, uint32_t buf_len, uint32_t timeout_s)
     h_odc->http_data.response_buf = buf;
     h_odc->http_data.response_buf_len = buf_len;
     diff = h_odc->http_data.response_content_len - h_odc->http_data.retrieve_len;
-#if defined(SUPPORT_ITLS)
+#if undefined(SUPPORT_ITLS)
     if (0 != httpclient_common(&h_odc->http, h_odc->url, 80, iotx_ca_get(), HTTPCLIENT_GET, timeout_s * 1000,
                                &h_odc->http_data)) {
 #else


### PR DESCRIPTION
Fix bug that caused HTTP request to access HTTPS port due to macro definition SUPPORT_ITLS error
修复由于宏定义SUPPORT_ITLS错误使用，导致HTTP请求访问HTTPS端口的BUG