### PR TITLE
Bug fix About OTA

### DIFF
--- a/src/services/linkkit/dm/dm_fota.c
+++ b/src/services/linkkit/dm/dm_fota.c
@@ -130,6 +130,7 @@ int dm_fota_perform_sync(_OU_ char *output, _IN_ int output_len)
             IOT_OTA_Ioctl(ota_handle, IOT_OTAG_CHECK_FIRMWARE, &file_isvalid, 4);
             if (file_isvalid == 0) {
                 HAL_Firmware_Persistence_Stop();
+                IOT_OTA_ReportProgress(ota_handle, IOT_OTAP_CHECK_FALIED, NULL);
                 ctx->is_report_new_config = 0;
                 return FAIL_RETURN;
             } else {

--- a/src/services/ota/impl/ota_lib.c
+++ b/src/services/ota/impl/ota_lib.c
@@ -44,6 +44,8 @@ void otalib_MD5Finalize(void *md5, char *output_str)
         output_str[i * 2 + 1] = utils_hb2hex(buf_out[i]);
     }
     output_str[32] = '\0';
+    utils_md5_init(md5);
+    utils_md5_starts(md5);
 }
 
 void otalib_MD5Deinit(void *md5)


### PR DESCRIPTION
修复和OTA固件升级有关的两个Bug.
1、在固件更新时如果固件MD5校验失败时，更新进度一直阻塞。
2、在多次固件更新时，由于MD5校验的初始化数据没有在初始化，会产生固件校验失败。