### PR TITLE
remove unnecessary space in CONFIG_ENV_CFLAGS 

### DIFF
--- a/tools/board/config.alios.esp8266
+++ b/tools/board/config.alios.esp8266
@@ -1,5 +1,5 @@
 CONFIG_ENV_CFLAGS   += \
-    -DBOARD_ESP8266 -u call_user_start \
+    -DBOARD_ESP8266 -ucall_user_start \
     -fno-inline-functions \
     -ffunction-sections \
     -fdata-sections \


### PR DESCRIPTION
avoid wrong CFLAGS generation.by defaults, " -u call_user_start "  changed to "-u -w call_user_start" after make reconfig, and result in call_user_start file not found

