### PR TITLE
docs: fix simple typo, prirority -> priority

### DIFF
--- a/external_libs/nghttp2/nghttp2_stream.c
+++ b/external_libs/nghttp2/nghttp2_stream.c
@@ -13,7 +13,7 @@
 #include "nghttp2_debug.h"
 
 /* Maximum distance between any two stream's cycle in the same
-   prirority queue.  Imagine stream A's cycle is A, and stream B's
+   priority queue.  Imagine stream A's cycle is A, and stream B's
    cycle is B, and A < B.  The cycle is unsigned 32 bit integer, it
    may get overflow.  Because of how we calculate the next cycle
    value, if B - A is less than or equals to


### PR DESCRIPTION
There is a small typo in external_libs/nghttp2/nghttp2_stream.c.

Should read `priority` rather than `prirority`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md